### PR TITLE
Return a proxy when traversing the help namespaces.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,10 +2,13 @@
  CHANGES
 =========
 
-4.0.2 (unreleased)
+4.1.0 (unreleased)
 ==================
 
-- Nothing changed yet.
+- The help namespace no longer modifies the global help object on
+  traversal. Instead it returns a new proxy object. This makes it
+  thread-safe. See `issue 4
+  <https://github.com/zopefoundation/zope.app.onlinehelp/issues/4>`_.
 
 
 4.0.1 (2017-05-21)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,10 @@
   thread-safe. See `issue 4
   <https://github.com/zopefoundation/zope.app.onlinehelp/issues/4>`_.
 
+- ``getTopicFor`` now really returns the first found topic in the
+  event that the object implements multiple interfaces that have
+  registered topics for the given view. Previously it would return the
+  topic for the least-specific interface.
 
 4.0.1 (2017-05-21)
 ==================

--- a/src/zope/app/onlinehelp/__init__.py
+++ b/src/zope/app/onlinehelp/__init__.py
@@ -137,12 +137,43 @@ def getTopicFor(obj, view=None):
     >>> getTopicFor(Dummy2()) is None
     True
 
+    If there is a second interface also provided with the same
+    view name and registered for that interface, still only the first
+    topic will be found.
+
+    >>> from zope.interface import Interface, implementer, alsoProvides
+    >>> class I3(Interface):
+    ...     pass
+    >>> @implementer(I3)
+    ... class Dummy3(object):
+    ...     pass
+
+    >>> path = os.path.join(testdir(), 'help2.txt')
+    >>> onlinehelp.registerHelpTopic('a', 'help3', 'Help 3',
+    ...     path, I3, None)
+
+    >>> getTopicFor(Dummy3()).title
+    'Help 3'
+    >>> getTopicFor(Dummy1()).title
+    'Help 2'
+
+    >>> @implementer(I1, I3)
+    ... class Dummy4(object):
+    ...     pass
+    >>> getTopicFor(Dummy4()).title
+    'Help 2'
+
+    >>> @implementer(I3, I1)
+    ... class Dummy5(object):
+    ...     pass
+    >>> getTopicFor(Dummy5()).title
+    'Help 3'
+
     """
     for interface in providedBy(obj):
         for _name, topic in getUtilitiesFor(IOnlineHelpTopic):
             if topic.interface == interface and topic.view == view:
                 return topic
-
 
 def _clear():
     globalhelp.__init__(globalhelp.title, globalhelp.path)

--- a/src/zope/app/onlinehelp/configure.zcml
+++ b/src/zope/app/onlinehelp/configure.zcml
@@ -14,6 +14,11 @@
         />
   </class>
 
+  <class class="._TraversedOnlineHelpProxy">
+	<require
+        like_class=".onlinehelp.OnlineHelp" />
+  </class>
+
   <!-- this is the generic help topic implementation -->
   <class class=".onlinehelptopic.OnlineHelpTopic">
     <require

--- a/src/zope/app/onlinehelp/metaconfigure.py
+++ b/src/zope/app/onlinehelp/metaconfigure.py
@@ -2,21 +2,20 @@
 #
 # Copyright (c) 2001, 2002 Zope Corporation and Contributors.
 # All Rights Reserved.
-# 
+#
 # This software is subject to the provisions of the Zope Public License,
 # Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
 # THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
 # WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 # WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
 # FOR A PARTICULAR PURPOSE.
-# 
+#
 ##############################################################################
 """Meta-Configuration Handlers for "help" namespace.
 
 These handlers process the `registerTopic()` directive of
 the "help" ZCML namespace.
 
-$Id$
 """
 __docformat__ = 'restructuredtext'
 
@@ -25,7 +24,7 @@ from zope.app.onlinehelp import globalhelp
 
 class OnlineHelpTopicDirective(object):
 
-    def __init__(self, _context, id, title, parent="", doc_path=None, 
+    def __init__(self, _context, id, title, parent="", doc_path=None,
         for_=None, view=None, class_=None, resources=None):
         self._context = _context
         self.id = id
@@ -36,7 +35,7 @@ class OnlineHelpTopicDirective(object):
         self.view = view
         self.class_ = class_
         self.resources = resources
-        
+
     def _args(self):
         return (self.parent, self.id, self.title, self.doc_path, self.for_,
                 self.view, self.class_, self.resources)

--- a/src/zope/app/onlinehelp/tests/test_onlinehelp.py
+++ b/src/zope/app/onlinehelp/tests/test_onlinehelp.py
@@ -70,9 +70,27 @@ class TestOnlineHelp(unittest.TestCase):
             'path that does not exist')
 
 
+class TestOnlineHelpNamespace(unittest.TestCase):
+
+    def test_context(self):
+        from zope.app.onlinehelp import globalhelp
+        from zope.app.onlinehelp import helpNamespace
+
+        traversed = helpNamespace(self).traverse(None, None)
+        self.assertIs(traversed.context, self)
+        self.assertIsNone(getattr(globalhelp, 'context', None))
+
+    def test_cannot_pickle(self):
+        from zope.app.onlinehelp import helpNamespace
+        import pickle
+
+        traversed = helpNamespace(self).traverse(None, None)
+        self.assertRaises(TypeError,
+                          pickle.dumps, traversed)
+
+
 def testdir():
-    import zope.app.onlinehelp.tests
-    return os.path.dirname(zope.app.onlinehelp.tests.__file__)
+    return os.path.dirname(__file__)
 
 def setUp(tests):
     testing.setUp()


### PR DESCRIPTION
Fixes #4 by returning a new proxy object, so we are thread-safe. Nothing in this project outside the metadirectives touches the `globalhelp` object so they shouldn't depend on it ever having a `context`.

This new object is just a plain proxy, not a LocationProxy. Trying to return a LocationProxy (with the `__name__` taken from the traversal name and the `__parent__` set to the context) causes lots of 404 errors from zope.app.apidoc (although no failures here). I suspect this is because OnlineHelp is supposed to be an IContainmentRoot, which isn't supposed to have a name.

Like LocationProxy, though, make the returned proxy not capable of being pickled.

I tested this with zope.app.apidoc with no issues as far as the test cases are concerned.